### PR TITLE
Remove ShortcutRecorder and Sparkle dependency until fixed

### DIFF
--- a/MidiKeys.xcodeproj/project.pbxproj
+++ b/MidiKeys.xcodeproj/project.pbxproj
@@ -20,8 +20,6 @@
 		02D211162309F2E7007F7B5E /* ColourDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 02D211072309F2E7007F7B5E /* ColourDefaults.m */; };
 		02D211172309F2E7007F7B5E /* EndpointDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 02D211092309F2E7007F7B5E /* EndpointDefaults.m */; };
 		02D211182309F2E7007F7B5E /* OverlayIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 02D2110A2309F2E7007F7B5E /* OverlayIndicator.m */; };
-		02D2112A2309F540007F7B5E /* ShortcutRecorder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02D211292309F540007F7B5E /* ShortcutRecorder.framework */; };
-		02D211392309FC4E007F7B5E /* ShortcutRecorder.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 02D211292309F540007F7B5E /* ShortcutRecorder.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		02D2113D2309FCE0007F7B5E /* CoreMIDI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02D2113C2309FCE0007F7B5E /* CoreMIDI.framework */; };
 		02D2113F2309FCEE007F7B5E /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02D2113E2309FCEE007F7B5E /* CoreAudio.framework */; };
 		02D2115C2309FEA8007F7B5E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 02D211462309FEA8007F7B5E /* Localizable.strings */; };
@@ -33,23 +31,7 @@
 		02D211642309FEA8007F7B5E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 02D211552309FEA8007F7B5E /* Assets.xcassets */; };
 		02D211672309FEA8007F7B5E /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 02D211582309FEA8007F7B5E /* dsa_pub.pem */; };
 		02D211692309FEA8007F7B5E /* KeyMaps.plist in Resources */ = {isa = PBXBuildFile; fileRef = 02D2115A2309FEA8007F7B5E /* KeyMaps.plist */; };
-		02F7664E234001630077D366 /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02F7664D234001630077D366 /* Sparkle.framework */; };
-		02F7664F234001630077D366 /* Sparkle.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 02F7664D234001630077D366 /* Sparkle.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		02D211382309FC35007F7B5E /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				02D211392309FC4E007F7B5E /* ShortcutRecorder.framework in CopyFiles */,
-				02F7664F234001630077D366 /* Sparkle.framework in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		027038902353CCE20042A6C3 /* ReadMe.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = ReadMe.rtf; sourceTree = SOURCE_ROOT; };
@@ -116,8 +98,6 @@
 			files = (
 				02D2113F2309FCEE007F7B5E /* CoreAudio.framework in Frameworks */,
 				02D2113D2309FCE0007F7B5E /* CoreMIDI.framework in Frameworks */,
-				02D2112A2309F540007F7B5E /* ShortcutRecorder.framework in Frameworks */,
-				02F7664E234001630077D366 /* Sparkle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,7 +203,6 @@
 				02D210D82309F20A007F7B5E /* Sources */,
 				02D210D92309F20A007F7B5E /* Frameworks */,
 				02D210DA2309F20A007F7B5E /* Resources */,
-				02D211382309FC35007F7B5E /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -499,7 +478,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/MidiKeys.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 26G7NGZPAT;
+				DEVELOPMENT_TEAM = UP6SS5ES7E;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -526,7 +505,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resources/MidiKeys.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 26G7NGZPAT;
+				DEVELOPMENT_TEAM = UP6SS5ES7E;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Source/Preferences.h
+++ b/Source/Preferences.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2002-2003 Chris Reed. All rights reserved.
 //
 
-#import <ShortcutRecorder/SRRecorderControl.h>
+// #import <ShortcutRecorder/SRRecorderControl.h>
 
 //! @name Preference Keys
 //@{

--- a/Source/PreferencesController.h
+++ b/Source/PreferencesController.h
@@ -8,12 +8,12 @@
 
 #import <Cocoa/Cocoa.h>
 #import "Preferences.h"
-#import <ShortcutRecorder/SRRecorderControl.h>
+// #import <ShortcutRecorder/SRRecorderControl.h>
 
 /*!
  * @brief Manages the preferences panel.
  */
-@interface PreferencesController : NSWindowController <SRRecorderControlDelegate>
+@interface PreferencesController : NSWindowController // <SRRecorderControlDelegate>
 {
 	IBOutlet NSWindow * _prefsWindow;
 	IBOutlet NSPopUpButton *keymapPopup;
@@ -30,7 +30,7 @@
     IBOutlet NSButton * _showCNotesCheckbox;
     IBOutlet NSButton * _forceLightModeCheckbox;
 	IBOutlet NSButton * _clickThroughCheckbox;
-	IBOutlet SRRecorderControl * _toggleHotKeysShortcut;
+//	IBOutlet SRRecorderControl * _toggleHotKeysShortcut;
     IBOutlet NSButton * _hotKeysOverlaysCheckbox;
     IBOutlet NSButton * _octaveShiftOverlaysCheckbox;
     IBOutlet NSButton * _velocityOverlaysCheckbox;

--- a/Source/PreferencesController.m
+++ b/Source/PreferencesController.m
@@ -9,7 +9,7 @@
 #import "PreferencesController.h"
 #import "ColourDefaults.h"
 #import "KeyMapManager.h"
-#import "ShortcutRecorder/ShortcutRecorder.h"
+// #import "ShortcutRecorder/ShortcutRecorder.h"
 #import "AppController.h"
 #import <Carbon/Carbon.h>
 
@@ -72,24 +72,24 @@ static PreferencesController *_sharedPrefsController = nil;
         [_forceLightModeCheckbox setHidden:YES];
     }
 
-    _toggleHotKeysShortcut.delegate = self;
+//    _toggleHotKeysShortcut.delegate = self;
 //    [_toggleHotKeysShortcut setCanCaptureGlobalHotKeys:YES];
 }
 
-- (BOOL)recorderControl:(SRRecorderControl *)aRecorder shouldUnconditionallyAllowModifierFlags:(NSEventModifierFlags)aModifierFlags forKeyCode:(unsigned short)aKeyCode
-{
-    return YES;
-}
-
-- (void)recorderControlDidBeginRecording:(SRRecorderControl *)aControl
-{
-    [[AppController sharedController] unregisterToggleHotKey];
-}
-
-- (void)recorderControlDidEndRecording:(SRRecorderControl *)aControl
-{
-    [[AppController sharedController] registerToggleHotKey];
-}
+//- (BOOL)recorderControl:(SRRecorderControl *)aRecorder shouldUnconditionallyAllowModifierFlags:(NSEventModifierFlags)aModifierFlags forKeyCode:(unsigned short)aKeyCode
+//{
+//    return YES;
+//}
+//
+//- (void)recorderControlDidBeginRecording:(SRRecorderControl *)aControl
+//{
+//    [[AppController sharedController] unregisterToggleHotKey];
+//}
+//
+//- (void)recorderControlDidEndRecording:(SRRecorderControl *)aControl
+//{
+//    [[AppController sharedController] registerToggleHotKey];
+//}
 
 - (void)showPanel:(id)sender
 {
@@ -162,31 +162,31 @@ static PreferencesController *_sharedPrefsController = nil;
     // mask to the Cocoa modifiers used by ShortcutRecorder. We also convert
     // the dict key names from those used by MidiKeys (for backwards compatibility)
     // to ShortcutRecorder's.
-    NSDictionary * toggleDict = [defaults dictionaryForKey:kToggleHotKeysShortcutPrefKey];
-    if (toggleDict)
-    {
-        NSNumber * flags = toggleDict[SHORTCUT_FLAGS_KEY];
-        NSNumber * convertedFlags;
-        if (flags)
-        {
-            convertedFlags = @(SRCarbonToCocoaFlags([flags intValue]));
-        }
-        else
-        {
-            convertedFlags = @(0);
-        }
-        NSNumber * keycode = toggleDict[SHORTCUT_KEYCODE_KEY];
-        if (!keycode)
-        {
-            keycode = @(0);
-        }
-        // Create the ShortcutRecorder key info dict.
-        toggleDict = @{
-            SRShortcutKeyModifierFlags: convertedFlags,
-            SRShortcutKeyKeyCode: keycode,
-            };
-    }
-    _toggleHotKeysShortcut.dictionaryValue = toggleDict;
+//    NSDictionary * toggleDict = [defaults dictionaryForKey:kToggleHotKeysShortcutPrefKey];
+//    if (toggleDict)
+//    {
+//        NSNumber * flags = toggleDict[SHORTCUT_FLAGS_KEY];
+//        NSNumber * convertedFlags;
+//        if (flags)
+//        {
+//            convertedFlags = @(SRCarbonToCocoaFlags([flags intValue]));
+//        }
+//        else
+//        {
+//            convertedFlags = @(0);
+//        }
+//        NSNumber * keycode = toggleDict[SHORTCUT_KEYCODE_KEY];
+//        if (!keycode)
+//        {
+//            keycode = @(0);
+//        }
+//        // Create the ShortcutRecorder key info dict.
+//        toggleDict = @{
+//            SRShortcutKeyModifierFlags: convertedFlags,
+//            SRShortcutKeyKeyCode: keycode,
+//            };
+//    }
+//    _toggleHotKeysShortcut.dictionaryValue = toggleDict;
 }
 
 //! @brief Save preferences to defaults and send prefs changed notification.
@@ -263,31 +263,31 @@ static PreferencesController *_sharedPrefsController = nil;
     // value as-is, we convert the modifier key mask from Cocoa to Carbon. This
     // keeps compatibility with previous preferences.  We also convert
     // the dict key names.
-    NSDictionary *toggleDict = _toggleHotKeysShortcut.dictionaryValue;
-    if (toggleDict)
-    {
-        NSNumber * flags = toggleDict[SRShortcutKeyModifierFlags];
-        NSNumber * convertedFlags;
-        if (flags)
-        {
-            convertedFlags = @(SRCocoaToCarbonFlags(flags.intValue));
-        }
-        else
-        {
-            convertedFlags = @(0);
-        }
-        NSNumber * keycode = toggleDict[SRShortcutKeyKeyCode];
-        if (!keycode)
-        {
-            keycode = @(0);
-        }
-        toggleDict = @{
-            SHORTCUT_FLAGS_KEY: convertedFlags,
-            SHORTCUT_KEYCODE_KEY: keycode,
-            };
-    }
-
-    [defaults setObject:toggleDict forKey:kToggleHotKeysShortcutPrefKey];
+//    NSDictionary *toggleDict = _toggleHotKeysShortcut.dictionaryValue;
+//    if (toggleDict)
+//    {
+//        NSNumber * flags = toggleDict[SRShortcutKeyModifierFlags];
+//        NSNumber * convertedFlags;
+//        if (flags)
+//        {
+//            convertedFlags = @(SRCocoaToCarbonFlags(flags.intValue));
+//        }
+//        else
+//        {
+//            convertedFlags = @(0);
+//        }
+//        NSNumber * keycode = toggleDict[SRShortcutKeyKeyCode];
+//        if (!keycode)
+//        {
+//            keycode = @(0);
+//        }
+//        toggleDict = @{
+//            SHORTCUT_FLAGS_KEY: convertedFlags,
+//            SHORTCUT_KEYCODE_KEY: keycode,
+//            };
+//    }
+//
+//    [defaults setObject:toggleDict forKey:kToggleHotKeysShortcutPrefKey];
 
 	// send notification that the prefs have changed
 	[[NSNotificationCenter defaultCenter] postNotificationName:kPreferencesChangedNotification object:nil];


### PR DESCRIPTION
This *removes* the dependencies own ShortcutRecorder and Sparkle which cause the app to not start on macOS 11 Big Sur. The issue is due to signing, but I was unable to get the right settings to work, so I punted and removed them. I doubt that this is the end goal, but maybe others can tweak to get the signing correct so Big Sur will load the libs at launch.